### PR TITLE
encode per doctype

### DIFF
--- a/_includes/search_include.html
+++ b/_includes/search_include.html
@@ -6,4 +6,4 @@
     <input type="submit" name="sa" value="Search" />
   </div>
 </form>
-<script type="text/javascript" src="http://www.google.com/coop/cse/brand?form=cse-search-box&lang=en"></script>
+<script type="text/javascript" src="http://www.google.com/coop/cse/brand?form=cse-search-box&amp;lang=en"></script>


### PR DESCRIPTION
`&` should be encoded as `amp;`, yes even in a `src` attribute...
